### PR TITLE
🐛 FIX: Import `dotenv` in Node.js example

### DIFF
--- a/examples/nodejs/examples/pipe.generate.text.ts
+++ b/examples/nodejs/examples/pipe.generate.text.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {generateText, Pipe} from '@baseai/core';
 import pipeSummary from '../baseai/pipes/summary';
 

--- a/examples/nodejs/examples/pipe.memory.stream.text.ts
+++ b/examples/nodejs/examples/pipe.memory.stream.text.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {getRunner, Pipe, streamText} from '@baseai/core';
 import chatWithDocs from '../baseai/pipes/chat-with-docs';
 

--- a/examples/nodejs/examples/pipe.run.stream.loop.ts
+++ b/examples/nodejs/examples/pipe.run.stream.loop.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {getRunner, getTextContent, Pipe} from '@baseai/core';
 import pipeSummary from '../baseai/pipes/summary';
 

--- a/examples/nodejs/examples/pipe.run.stream.ts
+++ b/examples/nodejs/examples/pipe.run.stream.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {getRunner, Pipe} from '@baseai/core';
 import pipeSummary from '../baseai/pipes/summary';
 

--- a/examples/nodejs/examples/pipe.run.ts
+++ b/examples/nodejs/examples/pipe.run.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {Pipe} from '@baseai/core';
 import pipeSummary from '../baseai/pipes/summary';
 

--- a/examples/nodejs/examples/pipe.stream.text.ts
+++ b/examples/nodejs/examples/pipe.stream.text.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import {getRunner, Pipe, streamText} from '@baseai/core';
 import pipeSummary from '../baseai/pipes/summary';
 


### PR DESCRIPTION
This PR fixes Node.js example by importing `dotenv` top of TS files.