### PR TITLE
📦 NEW: Deploy doc to memory

### DIFF
--- a/apps/baseai.dev/content/docs/deployment/deploy.mdx
+++ b/apps/baseai.dev/content/docs/deployment/deploy.mdx
@@ -68,3 +68,5 @@ baseai deploy --overwrite # or -o
 When you deploy a project to prod that uses BaseAI, ensure that `LANGBASE_API_KEY` is set in the production environment. This key is required to authenticate with Langbase and access deployed AI agents and memory.
 
 Use appropriate [Org or User API key](https://langbase.com/docs/api-reference/api-keys) to authenticate with Langbase.
+
+---

--- a/apps/baseai.dev/content/docs/deployment/document.mdx
+++ b/apps/baseai.dev/content/docs/deployment/document.mdx
@@ -16,10 +16,6 @@ modified: 2024-09-24
 
 Deploy a document to memory on [Langbase](https://langbase.com/) using the BaseAI CLI. Before you deploy a document, make sure you are [authenticated](/docs/deployment/authentication) with the BaseAI CLI.
 
-<Note>
-Please make sure to add `OPENAI_API_KEY` to `.env` file in the root of your project. This is required to generate embeddings for the document in the memory.
-</Note>
-
 ---
 
 ## Deploy a document

--- a/apps/baseai.dev/content/docs/deployment/document.mdx
+++ b/apps/baseai.dev/content/docs/deployment/document.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Deploy a document to memory'
+description: "Deploy a document to memory on Langbase using the BaseAI CLI."
+tags:
+    - baseai
+    - auth
+    - langbase
+    - deploy
+    - document
+section: 'Deployment'
+published: 2024-09-24
+modified: 2024-09-24
+---
+
+# Deploy a document to memory
+
+Deploy a document to memory on [Langbase](https://langbase.com/) using the BaseAI CLI. Before you deploy a document, make sure you are [authenticated](/docs/deployment/authentication) with the BaseAI CLI.
+
+<Note>
+Please make sure to add `OPENAI_API_KEY` to `.env` file in the root of your project. This is required to generate embeddings for the document in the memory.
+</Note>
+
+---
+
+## Deploy a document
+
+Pass the memory name and document name to the `deploy` command using the `--memory` flag or `-m` for short and `--document` flag or `-d` for short.
+
+```bash
+npx baseai@latest deploy -m <memory-name> -d <document-name>
+```
+
+### Document doesn't exist in memory on Langbase?
+
+The BaseAI CLI will add the missing provided document in memory.
+
+### Document exist in memory on Langbase?
+
+The BaseAI CLI will exit with message to run the command again with `--overwrite` flag to overwrite the document in memory.
+
+---
+
+## Overwrite a document in memory
+
+Overwrite the existing document in memory on Langbase using the `overwrite` flag or `-o` for short.
+
+```bash
+npx baseai@latest deploy -m <memory-name> -d <doc-name> -o
+```
+
+---
+
+## Example
+
+Here is an example of the command to deploy a document to memory on Langbase.
+
+```bash
+npx baseai@latest deploy -m chat-with-docs -d langbase.md
+```
+
+---

--- a/apps/baseai.dev/content/docs/memory/create.mdx
+++ b/apps/baseai.dev/content/docs/memory/create.mdx
@@ -23,7 +23,7 @@ Create a new memory using the `memory` command. It will ask you for name and des
 Let's use the name `chat-with-docs` for this example.
 
 ```bash
-baseai memory
+npx baseai@latest memory
 ```
 
 It creates a memory at `baseai/memory/chat-with-docs` in your current directory. Add documents to `baseai/memory/chat-with-docs/documents` for use.

--- a/apps/baseai.dev/content/docs/memory/embed-document.mdx
+++ b/apps/baseai.dev/content/docs/memory/embed-document.mdx
@@ -28,7 +28,7 @@ Please make sure to add `OPENAI_API_KEY` to `.env` file in the root of your proj
 Pass the memory name and document name to the `embed` command using the `--memory` flag or `-m` for short and `--document` flag or `-d` for short.
 
 ```bash
-baseai embed -m chat-with-docs -d document-name
+npx baseai@latest embed -m chat-with-docs -d document-name
 ```
 
 It will generate embeddings and update the memory index. If the document is already embedded, it will update the embeddings for the document.

--- a/apps/baseai.dev/content/docs/memory/embed.mdx
+++ b/apps/baseai.dev/content/docs/memory/embed.mdx
@@ -32,7 +32,7 @@ Make sure you have a memory [created](/docs/memory/create) a memory and added do
 Embed all memory documents and create a semantic index for the memory. Pass the memory name to the `embed` command using the `--memory` flag or `-m` for short.
 
 ```bash
-baseai embed -m chat-with-docs
+npx baseai@latest embed -m chat-with-docs
 ```
 
 It will generate embeddings for the documents and create an index for search. Your memory is now ready to be used with a Pipe.

--- a/apps/baseai.dev/content/docs/memory/list.mdx
+++ b/apps/baseai.dev/content/docs/memory/list.mdx
@@ -20,7 +20,7 @@ List all memory in your current project directory.
 Use the `memory list` command to list all memory in your current project directory.
 
 ```bash
-baseai memory --list
+npx baseai@latest memory --list
 ```
 
 It will list all memory in the current project directory.

--- a/apps/baseai.dev/content/docs/memory/retrieve.mdx
+++ b/apps/baseai.dev/content/docs/memory/retrieve.mdx
@@ -37,7 +37,7 @@ The output is from memory created in [quickstart guide](/docs/memory/quickstart)
 
 
 ```bash
-baseai retrieve -m chat-with-docs -q "Default LLM"
+npx baseai@latest retrieve -m chat-with-docs -q "Default LLM"
 ```
 
 ---

--- a/apps/baseai.dev/src/data/navigation.ts
+++ b/apps/baseai.dev/src/data/navigation.ts
@@ -176,8 +176,12 @@ const navigationData: NavigationItem[] = [
 				href: '/docs/deployment/authentication'
 			},
 			{
-				title: 'Deploy',
+				title: 'Deploy All',
 				href: '/docs/deployment/deploy'
+			},
+			{
+				title: 'Deploy Document',
+				href: '/docs/deployment/document'
 			}
 		]
 	},

--- a/examples/nodejs/.gitignore
+++ b/examples/nodejs/.gitignore
@@ -75,3 +75,7 @@ assets/img/.DS_Store
 .next
 # baseai
 /.baseai/
+# baseai
+**/.baseai/
+# env file
+.env

--- a/packages/baseai/package.json
+++ b/packages/baseai/package.json
@@ -66,6 +66,7 @@
 		"dotenv": "^16.4.5",
 		"execa": "^9.4.0",
 		"figures": "^6.1.0",
+		"find-up": "^7.0.0",
 		"get-package-json-file": "^2.0.0",
 		"hono": "^4.5.11",
 		"js-tiktoken": "^1.0.14",

--- a/packages/baseai/src/build/index.ts
+++ b/packages/baseai/src/build/index.ts
@@ -57,11 +57,9 @@ const buildTools = async () => {
 	listBuiltItems('Tools', builtTools, icons.tool);
 };
 
-export const buildSingleMemory = async ({
+export const buildMemory = async ({
 	memoryName
-}: {
-	memoryName: string;
-}) => {
+}: { memoryName?: string } = {}) => {
 	console.log('');
 	p.intro(heading({ text: 'MEMORY', sub: '', dim: true }));
 
@@ -82,77 +80,79 @@ export const buildSingleMemory = async ({
 		await fs.mkdir(outputPath, { recursive: true });
 	}
 
-	const memoryPath = path.join(sourcePath, memoryName);
-
-	// Get all files in the memory directory
-	const files = await fs.readdir(memoryPath);
-	const indexFile = files.find(file => file === 'index.ts');
-
-	// If no index.ts file is found, no memory entry file exists. Skip the build.
-	if (!indexFile) {
-		p.log.info('MEMORY: No index.ts file found. Skipping memory build.');
-		process.exit(1);
-	}
-
-	const inputFile = path.join(memoryPath, indexFile);
-	const outputFile = path.join(outputPath, `${memoryName}.json`);
-
-	const s = p.spinner();
-	s.start('Building memory');
-
 	const builtMemories: string[] = [];
-	try {
-		const { stdout } = await execAsync(
-			`npx tsx -e "import memoryConfig from '${inputFile}'; console.log(JSON.stringify(memoryConfig()))"`
-		);
-
-		await fs.writeFile(outputFile, stdout);
-		s.message(`Compiled ${memoryName}`);
-
-		builtMemories.push(memoryName);
-	} catch (error) {
-		s.stop(`Error compiling ${memoryName}: ${error}`);
-	}
-
-	s.stop('Build complete');
-	listBuiltItems('Memories', builtMemories, icons.memory);
-};
-
-const buildMemory = async () => {
-	console.log('');
-	p.intro(heading({ text: 'MEMORY', sub: '', dim: true }));
-
-	const sourcePath = path.join(process.cwd(), 'baseai', 'memory');
-	const outputPath = path.join(process.cwd(), '.baseai', 'memory');
-
-	try {
-		await fs.access(sourcePath);
-	} catch (error) {
-		p.log.info('No memory directory found. Skipping memory build.');
-		return;
-	}
-
-	await fs.mkdir(outputPath, { recursive: true });
-
-	const filesBaseDir = await fs.readdir(sourcePath);
-	const files = filesBaseDir.map(file => `${file}/index.ts`);
-	const tsFiles = files.filter(file => file.endsWith('.ts'));
-
-	if (tsFiles.length === 0) {
-		p.log.info('MEMORY: No index.ts file found. Skipping memory build.');
-		return;
-	}
-
 	const s = p.spinner();
-	s.start('Building memory');
+	let tsFiles: any[] = [];
 
-	const builtMemories: string[] = [];
+	// If a memoryName is provided, build only that memory
+	if (memoryName) {
+		const memoryPath = path.join(sourcePath, memoryName);
+
+		// Get all files in the memory directory
+		const files = await fs.readdir(memoryPath);
+		const indexFile = files.find(file => file === 'index.ts');
+
+		// If no index.ts file is found, no memory entry file exists. Skip the build.
+		if (!indexFile) {
+			p.log.info(
+				'MEMORY: No index.ts file found. Skipping memory build.'
+			);
+			process.exit(1);
+		}
+
+		tsFiles.push(path.join(memoryName, indexFile));
+	}
+
+	// If no memoryName is provided, build all memories
+	if (!memoryName) {
+		const filesBaseDir = await fs.readdir(sourcePath);
+
+		// Get only folders in the memory directory
+		const folderPromises = filesBaseDir.map(async file => {
+			const filePath = path.join(sourcePath, file);
+			const stats = await fs.stat(filePath);
+			return stats.isDirectory() ? file : '';
+		});
+
+		let allMemoryFolders = await Promise.all(folderPromises);
+
+		// Remove empty strings from the array
+		allMemoryFolders = allMemoryFolders.filter(folder => folder !== '');
+
+		if (allMemoryFolders.length === 0) {
+			p.log.info('MEMORY: No memory found. Skipping memory build.');
+			return;
+		}
+
+		// Get all index.ts files in the all the memory folders
+		const tsFilesPromise = allMemoryFolders.map(async memory => {
+			const filePath = path.join(sourcePath, memory);
+			const files = await fs.readdir(filePath);
+			const indexFile = files.find(file => file === 'index.ts');
+
+			// if index file, return the memory/index.ts path
+			return indexFile ? path.join(memory, indexFile) : '';
+		});
+
+		tsFiles = await Promise.all(tsFilesPromise);
+
+		// Remove empty strings from the array
+		tsFiles = tsFiles.filter(file => file !== '');
+
+		if (tsFiles.length === 0) {
+			p.log.info(
+				'MEMORY: No index.ts file found. Skipping memory build.'
+			);
+			return;
+		}
+	}
+
+	s.start('Building memory');
 
 	for (const file of tsFiles) {
 		const inputFile = path.join(sourcePath, file);
 		const outputFile = path.join(outputPath, `${path.dirname(file)}.json`);
 		const displayName = path.dirname(file); // This is the last directory name
-
 		try {
 			const { stdout } = await execAsync(
 				`npx tsx -e "import memoryConfig from '${inputFile}'; console.log(JSON.stringify(memoryConfig()))"`

--- a/packages/baseai/src/build/index.ts
+++ b/packages/baseai/src/build/index.ts
@@ -82,62 +82,16 @@ export const buildMemory = async ({
 
 	const builtMemories: string[] = [];
 	const s = p.spinner();
-	let tsFiles: any[] = [];
+	let tsFiles: string[] = [];
 
 	// If a memoryName is provided, build only that memory
 	if (memoryName) {
-		const memoryPath = path.join(sourcePath, memoryName);
-
-		// Get all files in the memory directory
-		const files = await fs.readdir(memoryPath);
-		const indexFile = files.find(file => file === 'index.ts');
-
-		// If no index.ts file is found, no memory entry file exists. Skip the build.
-		if (!indexFile) {
-			p.log.info(
-				'MEMORY: No index.ts file found. Skipping memory build.'
-			);
-			process.exit(1);
-		}
-
-		tsFiles.push(path.join(memoryName, indexFile));
+		tsFiles = await getSingleMemoryFile({ sourcePath, memoryName });
 	}
 
 	// If no memoryName is provided, build all memories
 	if (!memoryName) {
-		const filesBaseDir = await fs.readdir(sourcePath);
-
-		// Get only folders in the memory directory
-		const folderPromises = filesBaseDir.map(async file => {
-			const filePath = path.join(sourcePath, file);
-			const stats = await fs.stat(filePath);
-			return stats.isDirectory() ? file : '';
-		});
-
-		let allMemoryFolders = await Promise.all(folderPromises);
-
-		// Remove empty strings from the array
-		allMemoryFolders = allMemoryFolders.filter(folder => folder !== '');
-
-		if (allMemoryFolders.length === 0) {
-			p.log.info('MEMORY: No memory found. Skipping memory build.');
-			return;
-		}
-
-		// Get all index.ts files in the all the memory folders
-		const tsFilesPromise = allMemoryFolders.map(async memory => {
-			const filePath = path.join(sourcePath, memory);
-			const files = await fs.readdir(filePath);
-			const indexFile = files.find(file => file === 'index.ts');
-
-			// if index file, return the memory/index.ts path
-			return indexFile ? path.join(memory, indexFile) : '';
-		});
-
-		tsFiles = await Promise.all(tsFilesPromise);
-
-		// Remove empty strings from the array
-		tsFiles = tsFiles.filter(file => file !== '');
+		tsFiles = await getAllMemoryFile(sourcePath);
 
 		if (tsFiles.length === 0) {
 			p.log.info(
@@ -241,3 +195,73 @@ const listBuiltItems = (title: string, items: string[], icon: string) => {
 		// console.log(`\nNo ${title.toLowerCase()} were built.`);
 	}
 };
+
+async function getSingleMemoryFile({
+	sourcePath,
+	memoryName
+}: {
+	sourcePath: string;
+	memoryName: string;
+}) {
+	// Array to store the paths of the memory files
+	const tsFiles: string[] = [];
+
+	const memoryPath = path.join(sourcePath, memoryName);
+
+	// Get all files in the memory directory
+	const files = await fs.readdir(memoryPath);
+	const indexFile = files.find(file => file === 'index.ts');
+
+	// If no index.ts file is found, no memory entry file exists. Skip the build.
+	if (!indexFile) {
+		p.log.info('MEMORY: No index.ts file found. Skipping memory build.');
+		process.exit(1); // Exiting process because it is a single memory build.
+	}
+
+	tsFiles.push(path.join(memoryName, indexFile));
+
+	return tsFiles;
+}
+
+async function getAllMemoryFile(sourcePath: string) {
+	// Array to store the paths of the memory files
+	let tsFiles: string[] = [];
+
+	// Get all folders in the memory directory
+	const filesBaseDir = await fs.readdir(sourcePath);
+
+	// Get only folders in the memory directory
+	const folderPromises = filesBaseDir.map(async file => {
+		const filePath = path.join(sourcePath, file);
+		const stats = await fs.stat(filePath);
+		return stats.isDirectory() ? file : '';
+	});
+
+	let allMemoryFolders = await Promise.all(folderPromises);
+
+	// Remove empty strings from the array
+	allMemoryFolders = allMemoryFolders.filter(folder => folder !== '');
+
+	if (allMemoryFolders.length === 0) {
+		p.log.info('MEMORY: No memory found. Skipping memory build.');
+		return [];
+	}
+
+	// Get all index.ts files in the all the memory folders
+	const tsFilesPromise = allMemoryFolders.map(async memory => {
+		const filePath = path.join(sourcePath, memory);
+		const files = await fs.readdir(filePath);
+		const indexFile = files.find(file => file === 'index.ts');
+
+		// if index file, return the memory/index.ts path
+		return indexFile ? path.join(memory, indexFile) : '';
+	});
+
+	// Wait for all the promises to resolve
+	tsFiles = await Promise.all(tsFilesPromise);
+
+	// Remove empty strings from the array
+	tsFiles = tsFiles.filter(file => file !== '');
+
+	return tsFiles;
+}

--- a/packages/baseai/src/build/index.ts
+++ b/packages/baseai/src/build/index.ts
@@ -69,6 +69,13 @@ export const buildSingleMemory = async ({
 	const outputPath = path.join(process.cwd(), '.baseai', 'memory');
 
 	try {
+		await fs.access(outputPath);
+	} catch (error) {
+		// Create the memory directory if it doesn't exist
+		await fs.mkdir(outputPath, { recursive: true });
+	}
+
+	try {
 		await fs.access(sourcePath);
 	} catch (error) {
 		p.log.info('No memory directory found. Skipping memory build.');

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -1,4 +1,4 @@
-import { buildSingleMemory } from '@/build';
+import { buildMemory } from '@/build';
 import { heading } from '@/utils/heading';
 import { isMemoryDocExist } from '@/utils/memory/check-memory-doc-exists';
 import * as p from '@clack/prompts';
@@ -40,7 +40,7 @@ export async function deploySingleDocument({
 
 		spinner.stop('Loaded docs');
 
-		await buildSingleMemory({ memoryName: validMemoryName });
+		await buildMemory({ memoryName: validMemoryName });
 		const buildDir = path.join(process.cwd(), '.baseai');
 		const memoryDir = path.join(buildDir, 'memory');
 

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -146,6 +146,7 @@ async function deployDocument({
 				error,
 				type: 'memory'
 			});
+			process.exit(1);
 		}
 	} catch (error) {
 		handleDeploymentError({
@@ -154,6 +155,6 @@ async function deployDocument({
 			error,
 			type: 'memory'
 		});
-		throw error;
+		process.exit(1);
 	}
 }

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -115,7 +115,7 @@ async function deployDocument({
 			process.exit(1);
 		}
 
-		await handleSingleMemoryDeploy({
+		await handleSingleDocDeploy({
 			memory: memoryObject,
 			account,
 			document,
@@ -136,7 +136,7 @@ async function deployDocument({
 	}
 }
 
-export async function handleSingleMemoryDeploy({
+export async function handleSingleDocDeploy({
 	memory,
 	account,
 	document,

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -1,3 +1,134 @@
-export async function deploySingleDocument() {
-	console.log('Deploying single document');
+import { buildSingleMemory } from '@/build';
+import { heading } from '@/utils/heading';
+import { isMemoryDocExist } from '@/utils/memory/check-memory-doc-exists';
+import * as p from '@clack/prompts';
+import {
+	handleDeploymentError,
+	handleError,
+	handleInvalidConfig,
+	retrieveAuthentication,
+	uploadDocumentsToMemory,
+	type Account
+} from '.';
+import path from 'path';
+import fs from 'fs/promises';
+import { cyan } from '@/utils/formatting';
+import { loadMemoryFiles } from '@/utils/memory/load-memory-files';
+import { dlog } from '@/dev/utils/dlog';
+
+type Spinner = ReturnType<typeof p.spinner>;
+
+export async function deploySingleDocument({
+	memoryName,
+	documentName
+}: {
+	memoryName: string;
+	documentName: string;
+}) {
+	p.intro(heading({ text: 'DEPLOY', sub: 'Deploy a single document' }));
+
+	const spinner = p.spinner();
+	try {
+		const { validDocumentName, validMemoryName } = await isMemoryDocExist({
+			spinner,
+			memoryName,
+			documentName
+		});
+
+		spinner.stop();
+
+		await buildSingleMemory({ memoryName: validMemoryName });
+		const buildDir = path.join(process.cwd(), '.baseai');
+		const memoryDir = path.join(buildDir, 'memory');
+
+		const account = await retrieveAuthentication({ spinner });
+		if (!account) {
+			p.outro(
+				`No account found. Skipping deployment. \n Run: ${cyan('npx baseai@latest auth')}`
+			);
+			process.exit(1);
+		}
+
+		await deployDocument({
+			account,
+			spinner,
+			memoryDir,
+			memoryName: validMemoryName,
+			documentName: validDocumentName
+		});
+
+		p.outro(
+			heading({ text: 'DEPLOYED', sub: 'successfully', green: true })
+		);
+	} catch (error) {
+		handleError({
+			spinner,
+			message: 'An unexpected error occurred',
+			error
+		});
+	}
+}
+
+async function deployDocument({
+	spinner,
+	memoryDir,
+	memoryName,
+	documentName,
+	account
+}: {
+	memoryDir: string;
+	spinner: Spinner;
+	memoryName: string;
+	documentName: string;
+	account: Account;
+}) {
+	const memoryPath = path.join(memoryDir, `${memoryName}.json`);
+	spinner.start(`Processing memory: ${documentName}`);
+	try {
+		const memoryContent = await fs.readFile(memoryPath, 'utf-8');
+		const memoryObject = JSON.parse(memoryContent);
+
+		if (!memoryObject) {
+			handleInvalidConfig({ spinner, name: memoryName, type: 'memory' });
+			process.exit(1);
+		}
+
+		p.log.step(`Processing ${documentName} of memory: ${memoryName}`);
+		const memoryDocs = await loadMemoryFiles(memoryName);
+
+		const document = memoryDocs.find(doc => doc.name === documentName);
+
+		if (!document) {
+			spinner.stop(
+				`Document ${documentName} not found in memory ${memoryName}`
+			);
+			process.exit(1);
+		}
+
+		spinner.stop(`Processed ${documentName} of memory: ${memoryName}`);
+
+		try {
+			await uploadDocumentsToMemory({
+				documents: [document],
+				name: memoryObject.name,
+				account
+			});
+		} catch (error) {
+			dlog('Error in upsertMemory:', error);
+			handleDeploymentError({
+				spinner,
+				name: memoryName,
+				error,
+				type: 'memory'
+			});
+		}
+	} catch (error) {
+		handleDeploymentError({
+			spinner,
+			name: memoryName,
+			error,
+			type: 'memory'
+		});
+		throw error;
+	}
 }

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -89,7 +89,6 @@ async function deployDocument({
 	documentName: string;
 }) {
 	const memoryPath = path.join(memoryDir, `${memoryName}.json`);
-	spinner.start(`Processing memory: ${documentName}`);
 	try {
 		const memoryContent = await fs.readFile(memoryPath, 'utf-8');
 		const memoryObject = JSON.parse(memoryContent);

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -1,0 +1,3 @@
+export async function deploySingleDocument() {
+	console.log('Deploying single document');
+}

--- a/packages/baseai/src/deploy/index.ts
+++ b/packages/baseai/src/deploy/index.ts
@@ -19,7 +19,7 @@ import type { MemoryI } from 'types/memory';
 import type { Pipe, PipeOld } from 'types/pipe';
 import { getStoredAuth } from './../auth/index';
 
-interface Account {
+export interface Account {
 	login: string;
 	apiKey: string;
 }
@@ -153,7 +153,7 @@ async function readToolsDirectory({
 	}
 }
 
-async function retrieveAuthentication({
+export async function retrieveAuthentication({
 	spinner
 }: {
 	spinner: Spinner;
@@ -316,7 +316,7 @@ async function updateExistingPipe({
 	return (await updateResponse.json()) as PipeOld;
 }
 
-function handleError({
+export function handleError({
 	spinner,
 	message,
 	error
@@ -366,7 +366,7 @@ function handleAuthError({
 	p.log.error(`Error retrieving stored auth: ${(error as Error).message}`);
 }
 
-function handleInvalidConfig({
+export function handleInvalidConfig({
 	spinner,
 	name,
 	type
@@ -379,7 +379,7 @@ function handleInvalidConfig({
 	p.log.error(`Invalid ${type} configuration`);
 }
 
-function handleDeploymentError({
+export function handleDeploymentError({
 	spinner,
 	error,
 	name,
@@ -407,7 +407,7 @@ function handleFileProcessingError({
 	p.log.error(`File processing error: ${(error as Error).message}`);
 }
 
-async function readMemoryDirectory({
+export async function readMemoryDirectory({
 	spinner,
 	memoryDir
 }: {
@@ -449,7 +449,7 @@ async function deployMemories({
 	}
 }
 
-async function deployMemory({
+export async function deployMemory({
 	spinner,
 	memoryName,
 	memoryDir,
@@ -511,7 +511,7 @@ async function deployMemory({
 	}
 }
 
-async function upsertMemory({
+export async function upsertMemory({
 	memory,
 	documents,
 	account,
@@ -573,7 +573,7 @@ async function upsertMemory({
 	}
 }
 
-async function uploadDocumentsToMemory({
+export async function uploadDocumentsToMemory({
 	documents,
 	name,
 	account
@@ -597,7 +597,6 @@ async function uploadDocumentsToMemory({
 
 			p.log.message(`Uploaded document: ${doc.name}`);
 		} catch (error) {
-			console.error('Error in uploadDocumentToMemory:', error);
 			throw error;
 		}
 	}
@@ -868,7 +867,7 @@ async function uploadDocument(signedUrl: string, document: Blob) {
 	}
 }
 
-function getMemoryApiUrls({
+export function getMemoryApiUrls({
 	account,
 	memoryName
 }: {

--- a/packages/baseai/src/index.ts
+++ b/packages/baseai/src/index.ts
@@ -20,6 +20,7 @@ import { setLocalEmbeddingsConfig } from './utils/config/set-local-embeddings';
 import debugMode from './utils/debug-mode';
 import cliInit from './utils/init';
 import { initLogger } from './utils/logger-utils';
+import { deploySingleDocument } from './deploy/document';
 
 const { flags, input, showHelp } = cli;
 const { clear, debug } = flags;
@@ -71,10 +72,26 @@ const flag = (flg: string): boolean => Boolean(flags[flg]);
 		await build({ calledAsCommand: true });
 	}
 
-	if (command('deploy')) {
+	// Deploy all
+	if (
+		command('deploy') &&
+		!flag('memory') &&
+		!flag('document') &&
+		!flag('overwrite')
+	) {
 		await deploy({
 			overwrite: flags.overwrite
 		});
+	}
+
+	// Deploy single document
+	if (
+		command('deploy') &&
+		flag('memory') &&
+		flag('document') &&
+		flag('overwrite')
+	) {
+		await deploySingleDocument();
 	}
 
 	if (command('memory') && flag('list')) {

--- a/packages/baseai/src/index.ts
+++ b/packages/baseai/src/index.ts
@@ -73,12 +73,7 @@ const flag = (flg: string): boolean => Boolean(flags[flg]);
 	}
 
 	// Deploy all
-	if (
-		command('deploy') &&
-		!flag('memory') &&
-		!flag('document') &&
-		!flag('overwrite')
-	) {
+	if (command('deploy') && !flag('memory') && !flag('document')) {
 		await deploy({
 			overwrite: flags.overwrite
 		});

--- a/packages/baseai/src/index.ts
+++ b/packages/baseai/src/index.ts
@@ -91,7 +91,10 @@ const flag = (flg: string): boolean => Boolean(flags[flg]);
 		flag('document') &&
 		flag('overwrite')
 	) {
-		await deploySingleDocument();
+		await deploySingleDocument({
+			memoryName: flags.memory,
+			documentName: flags.document
+		});
 	}
 
 	if (command('memory') && flag('list')) {

--- a/packages/baseai/src/index.ts
+++ b/packages/baseai/src/index.ts
@@ -85,15 +85,11 @@ const flag = (flg: string): boolean => Boolean(flags[flg]);
 	}
 
 	// Deploy single document
-	if (
-		command('deploy') &&
-		flag('memory') &&
-		flag('document') &&
-		flag('overwrite')
-	) {
+	if (command('deploy') && flag('memory') && flag('document')) {
 		await deploySingleDocument({
 			memoryName: flags.memory,
-			documentName: flags.document
+			documentName: flags.document,
+			overwrite: flags.overwrite
 		});
 	}
 
@@ -105,7 +101,7 @@ const flag = (flg: string): boolean => Boolean(flags[flg]);
 		await createMemory();
 	}
 
-	if (command('embed') && flag('document')) {
+	if (command('embed') && flag('document') && flag('memory')) {
 		await embedDoc({
 			memoryName: flags.memory,
 			documentName: flags.document,

--- a/packages/baseai/src/memory/embed-doc.ts
+++ b/packages/baseai/src/memory/embed-doc.ts
@@ -1,8 +1,6 @@
 import { heading } from '@/utils/heading';
-import { checkMemoryExists } from '@/utils/memory/check-memory-exist';
+import { isMemoryDocExist } from '@/utils/memory/check-memory-doc-exists';
 import { generateEmbeddings } from '@/utils/memory/generate-embeddings';
-import { validatedocEmbedSchema } from '@/utils/memory/lib';
-import { loadMemoryFiles } from '@/utils/memory/load-memory-files';
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 
@@ -23,65 +21,26 @@ export async function embedDoc({
 	);
 
 	// Spinner to show current action.
-	const s = p.spinner();
+	const spinner = p.spinner();
 
 	try {
-		if (!memoryName) {
-			p.cancel(
-				'Memory name is required. Use --memory or -m flag to specify.'
-			);
-			process.exit(1);
-		}
+		const { memoryFile, validMemoryName } = await isMemoryDocExist({
+			spinner,
+			memoryName,
+			documentName
+		});
 
-		if (!documentName) {
-			p.cancel(
-				'Document name is required. Use --document or -d flag to specify.'
-			);
-			process.exit(1);
-		}
-
-		// 1- Check memory exists.
-		// s.start('Validating memory...');
-		const { memoryName: validMemoryName, documentName: validDocumentName } =
-			validatedocEmbedSchema({
-				memoryName,
-				documentName
-			});
-		await checkMemoryExists(validMemoryName);
-
-		// 2- Load memory data.
-		s.start('Processing docs...');
-		const memoryFiles = await loadMemoryFiles(validMemoryName);
-
-		if (memoryFiles.length === 0) {
-			p.cancel(`No valid documents found in memory '${memoryName}'.`);
-			process.exit(1);
-		}
-
-		// Find the document file.
-		const memoryFile = memoryFiles.find(
-			file => file.name === validDocumentName
-		);
-
-		if (!memoryFile) {
-			s.stop(`Stopped!`);
-			p.cancel(
-				`Doc: ${color.cyan(validDocumentName)} not found in memory ${validMemoryName}`
-			);
-			process.exit(1);
-		}
-
-		// 3- Generate embeddings.
-		s.message('Generating embeddings...');
+		// Generate embeddings.
+		spinner.message('Generating embeddings...');
 		const result = await generateEmbeddings({
 			memoryFiles: [memoryFile],
 			memoryName: validMemoryName,
 			overwrite: overwrite || false
 		});
 
-		s.stop(result);
+		spinner.stop(result);
 	} catch (error: any) {
-		s.stop(`FAILED from here: ${error.message}`);
+		spinner.stop(`FAILED from here: ${error.message}`);
 		process.exit(1);
 	}
 }

--- a/packages/baseai/src/utils/init.ts
+++ b/packages/baseai/src/utils/init.ts
@@ -1,11 +1,19 @@
 import unhandled from 'cli-handle-unhandled';
 import welcome from 'cli-welcome';
-import { getPackageJson } from 'get-package-json-file';
+import { findUpSync } from 'find-up';
+import fs from 'fs';
 
 export default async ({ clear = false }) => {
 	unhandled();
 
-	const pkgJson = await getPackageJson(`../../package.json`);
+	const pkgJsonPath = findUpSync('package.json');
+
+	if (!pkgJsonPath) {
+		console.error('Unable to find package.json');
+		process.exit(1);
+	}
+
+	const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
 
 	await welcome({
 		title: `baseai`,

--- a/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
+++ b/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
@@ -30,15 +30,16 @@ export const isMemoryDocExist = async ({
 	}
 
 	// 1- Check memory exists.
-	// s.start('Validating memory...');
 	const { memoryName: validMemoryName, documentName: validDocumentName } =
 		validateMemoryDocNames({
 			memoryName,
 			documentName
 		});
+
+	// 2- Check if memory exists.
 	await checkMemoryExists(validMemoryName);
 
-	// 2- Load memory data.
+	// 3- Load memory data.
 	spinner.start('Loading docs...');
 	const memoryFiles = await loadMemoryFiles(validMemoryName);
 

--- a/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
+++ b/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
@@ -1,0 +1,68 @@
+import * as p from '@clack/prompts';
+import { checkMemoryExists } from './check-memory-exist';
+import { loadMemoryFiles } from './load-memory-files';
+import color from 'picocolors';
+import { validateMemoryDocNames } from './lib';
+
+type Spinner = ReturnType<typeof p.spinner>;
+
+export const isMemoryDocExist = async ({
+	memoryName,
+	documentName,
+	spinner
+}: {
+	memoryName: string;
+	documentName: string;
+	spinner: Spinner;
+}) => {
+	if (!memoryName) {
+		p.cancel(
+			'Memory name is required. Use --memory or -m flag to specify.'
+		);
+		process.exit(1);
+	}
+
+	if (!documentName) {
+		p.cancel(
+			'Document name is required. Use --document or -d flag to specify.'
+		);
+		process.exit(1);
+	}
+
+	// 1- Check memory exists.
+	// s.start('Validating memory...');
+	const { memoryName: validMemoryName, documentName: validDocumentName } =
+		validateMemoryDocNames({
+			memoryName,
+			documentName
+		});
+	await checkMemoryExists(validMemoryName);
+
+	// 2- Load memory data.
+	spinner.start('Processing docs...');
+	const memoryFiles = await loadMemoryFiles(validMemoryName);
+
+	if (memoryFiles.length === 0) {
+		p.cancel(`No valid documents found in memory '${memoryName}'.`);
+		process.exit(1);
+	}
+
+	// Find the document file.
+	const memoryFile = memoryFiles.find(
+		file => file.name === validDocumentName
+	);
+
+	if (!memoryFile) {
+		spinner.stop(`Stopped!`);
+		p.cancel(
+			`Doc: ${color.cyan(validDocumentName)} not found in memory ${validMemoryName}`
+		);
+		process.exit(1);
+	}
+
+	return {
+		memoryFile,
+		validMemoryName,
+		validDocumentName
+	};
+};

--- a/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
+++ b/packages/baseai/src/utils/memory/check-memory-doc-exists.ts
@@ -39,7 +39,7 @@ export const isMemoryDocExist = async ({
 	await checkMemoryExists(validMemoryName);
 
 	// 2- Load memory data.
-	spinner.start('Processing docs...');
+	spinner.start('Loading docs...');
 	const memoryFiles = await loadMemoryFiles(validMemoryName);
 
 	if (memoryFiles.length === 0) {

--- a/packages/baseai/src/utils/memory/compare-docs-list.ts
+++ b/packages/baseai/src/utils/memory/compare-docs-list.ts
@@ -36,16 +36,14 @@ export function compareDocumentLists({
 		!localDocs.some(doc => prodSet.has(doc)) &&
 		!prodDocs.some(doc => localSet.has(doc));
 
-	// Case 5: Local doc is missing in prod
-	const isLocalDocumentMissingInProd = localDocs.some(
-		doc => !prodSet.has(doc)
-	);
+	// Case 5: Partial overlap
+	const areOverlapping = localDocs.some(doc => prodSet.has(doc));
 
 	return {
 		areListsSame,
 		isProdSubsetOfLocal,
 		isProdSupersetOfLocal,
 		areMutuallyExclusive,
-		isLocalDocumentMissingInProd
+		areOverlapping
 	};
 }

--- a/packages/baseai/src/utils/memory/compare-docs-list.ts
+++ b/packages/baseai/src/utils/memory/compare-docs-list.ts
@@ -36,10 +36,16 @@ export function compareDocumentLists({
 		!localDocs.some(doc => prodSet.has(doc)) &&
 		!prodDocs.some(doc => localSet.has(doc));
 
+	// Case 5: Local doc is missing in prod
+	const isLocalDocumentMissingInProd = localDocs.some(
+		doc => !prodSet.has(doc)
+	);
+
 	return {
 		areListsSame,
 		isProdSubsetOfLocal,
 		isProdSupersetOfLocal,
-		areMutuallyExclusive
+		areMutuallyExclusive,
+		isLocalDocumentMissingInProd
 	};
 }

--- a/packages/baseai/src/utils/memory/lib.ts
+++ b/packages/baseai/src/utils/memory/lib.ts
@@ -16,7 +16,7 @@ import {
 } from './db/lib';
 // import { generateLocalEmbeddings } from './generate-local-embeddings';
 import { dlog } from '@/dev/utils/dlog';
-import { docEmbedSchema, memoryNameSchema } from 'types/memory';
+import { memoryDocSchema, memoryNameSchema } from 'types/memory';
 import { loadConfig } from '../config/config-handler';
 import { logger } from '../logger-utils';
 import { generateLocalEmbeddings } from './generate-local-embeddings';
@@ -82,14 +82,14 @@ export const validateMemoryName = (memoryName: string) => {
 	return validatedName.data;
 };
 
-export const validatedocEmbedSchema = ({
+export const validateMemoryDocNames = ({
 	memoryName,
 	documentName
 }: {
 	memoryName: string;
 	documentName: string;
 }) => {
-	const validatedData = docEmbedSchema.safeParse({
+	const validatedData = memoryDocSchema.safeParse({
 		memoryName,
 		documentName
 	});

--- a/packages/baseai/src/utils/memory/load-memory-files.ts
+++ b/packages/baseai/src/utils/memory/load-memory-files.ts
@@ -85,3 +85,29 @@ export const loadMemoryFiles = async (
 
 	return memoryFilesContentFiltered;
 };
+
+export const getMemoryFileNames = async (
+	memoryName: string
+): Promise<string[]> => {
+	const memoryDir = path.join(process.cwd(), 'baseai', 'memory', memoryName);
+	const memoryFilesPath = path.join(memoryDir, 'documents');
+
+	try {
+		await fs.access(memoryFilesPath);
+	} catch (error) {
+		console.error(
+			`Documents directory for memory '${memoryName}' does not exist.`
+		);
+		return [];
+	}
+
+	try {
+		const memoryFiles = await fs.readdir(memoryFilesPath);
+		return memoryFiles.filter(file =>
+			allSupportedExtensions.some(extension => file.endsWith(extension))
+		);
+	} catch (error) {
+		console.error(`Failed to read documents in memory '${memoryName}'.`);
+		return [];
+	}
+};

--- a/packages/baseai/types/memory.ts
+++ b/packages/baseai/types/memory.ts
@@ -14,7 +14,9 @@ export const memoryNameSchema = z
 		'Memory name can only contain letters, numbers, dots, and hyphens'
 	);
 
-export const docEmbedSchema = z.object({
+export const docNameSchema = z.string().trim().min(1);
+
+export const memoryDocSchema = z.object({
 	memoryName: memoryNameSchema,
-	documentName: z.string().trim().min(1)
+	documentName: docNameSchema
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 2.0.0
       next:
         specifier: ^14.0.4
-        version: 14.2.5(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-mdx-remote:
         specifier: ^5.0.0
         version: 5.0.0(@types/react@18.3.11)(react@18.3.1)
@@ -261,7 +261,7 @@ importers:
         version: 5.1.1(astro@4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2))(tailwindcss@3.4.13(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2)))(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))
       '@astrojs/vercel':
         specifier: ^7.8.1
-        version: 7.8.1(astro@4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2))(next@14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 7.8.1(astro@4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2))(next@14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@baseai/core':
         specifier: ^0.9.4
         version: 0.9.4(react@18.3.1)(zod@3.23.8)
@@ -334,7 +334,7 @@ importers:
         version: 2.0.0
       next:
         specifier: 14.2.5
-        version: 14.2.5(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.53.0
         version: 4.67.1(zod@3.23.8)
@@ -385,15 +385,15 @@ importers:
   examples/nodejs:
     dependencies:
       '@baseai/core':
-        specifier: ^0.9.4
-        version: 0.9.4(react@18.3.1)(zod@3.23.8)
+        specifier: workspace:*
+        version: link:../../packages/core
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
     devDependencies:
       baseai:
-        specifier: ^0.9.4
-        version: 0.9.4(@types/node@22.7.4)(typescript@5.6.2)
+        specifier: workspace:*
+        version: link:../../packages/baseai
       tsx:
         specifier: ^4.19.0
         version: 4.19.1
@@ -442,7 +442,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: 2.12.0
-        version: 2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0)
+        version: 2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.11
@@ -457,7 +457,7 @@ importers:
         version: 6.21.0(eslint@8.57.1)(typescript@5.6.2)
       '@vercel/remix':
         specifier: 2.12.0
-        version: 2.12.0(@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0))(@remix-run/node@2.12.0(typescript@5.6.2))(@remix-run/server-runtime@2.12.0(typescript@5.6.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.12.0(@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0)))(@remix-run/node@2.12.0(typescript@5.6.2))(@remix-run/server-runtime@2.12.0(typescript@5.6.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -563,6 +563,9 @@ importers:
       figures:
         specifier: ^6.1.0
         version: 6.1.0
+      find-up:
+        specifier: ^7.0.0
+        version: 7.0.0
       get-package-json-file:
         specifier: ^2.0.0
         version: 2.0.0
@@ -5240,6 +5243,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
+
   find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
 
@@ -6183,6 +6190,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -7094,6 +7105,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
@@ -7109,6 +7124,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -7181,6 +7200,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -8700,6 +8723,10 @@ packages:
   unenv-nightly@2.0.0-20240919-125358-9a64854:
     resolution: {integrity: sha512-XjsgUTrTHR7iw+k/SRTNjh6EQgwpC9voygnoCJo5kh4hKqsSDHUW84MhL9EsHTNfLctvVBHaSw8e2k3R2fKXsQ==}
 
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -9613,10 +9640,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@7.8.1(astro@4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2))(next@14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@astrojs/vercel@7.8.1(astro@4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2))(next@14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
-      '@vercel/analytics': 1.3.1(next@14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@vercel/analytics': 1.3.1(next@14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/edge': 1.1.2
       '@vercel/nft': 0.27.4
       astro: 4.15.10(@types/node@22.7.4)(rollup@4.24.0)(terser@5.34.1)(typescript@5.6.2)
@@ -11191,7 +11218,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
-  '@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0)':
+  '@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))':
     dependencies:
       '@babel/core': 7.25.7
       '@babel/generator': 7.25.7
@@ -11980,11 +12007,11 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
-  '@vercel/analytics@1.3.1(next@14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.3.1(next@14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       server-only: 0.0.1
     optionalDependencies:
-      next: 14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@vercel/build-utils@8.4.5': {}
@@ -12133,9 +12160,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vercel/remix@2.12.0(@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0))(@remix-run/node@2.12.0(typescript@5.6.2))(@remix-run/server-runtime@2.12.0(typescript@5.6.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@vercel/remix@2.12.0(@remix-run/dev@2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0)))(@remix-run/node@2.12.0(typescript@5.6.2))(@remix-run/server-runtime@2.12.0(typescript@5.6.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@remix-run/dev': 2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0)
+      '@remix-run/dev': 2.12.0(@remix-run/react@2.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.0(typescript@5.6.2))(@types/node@22.7.4)(terser@5.34.1)(ts-node@10.9.1(@types/node@22.7.4)(typescript@5.6.2))(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.34.1))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))
       '@remix-run/node': 2.12.0(typescript@5.6.2)
       '@remix-run/server-runtime': 2.12.0(typescript@5.6.2)
       '@vercel/static-config': 3.0.0
@@ -14709,6 +14736,12 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
+
   find-yarn-workspace-root2@1.2.16:
     dependencies:
       micromatch: 4.0.8
@@ -15723,6 +15756,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
 
   lodash.camelcase@4.3.0: {}
 
@@ -16819,37 +16856,11 @@ snapshots:
 
   next-themes@0.2.1(next@14.2.5(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 14.2.5(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.5(@babel/core@7.25.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.5
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001666
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.7)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.5
-      '@next/swc-darwin-x64': 14.2.5
-      '@next/swc-linux-arm64-gnu': 14.2.5
-      '@next/swc-linux-arm64-musl': 14.2.5
-      '@next/swc-linux-x64-gnu': 14.2.5
-      '@next/swc-linux-x64-musl': 14.2.5
-      '@next/swc-win32-arm64-msvc': 14.2.5
-      '@next/swc-win32-ia32-msvc': 14.2.5
-      '@next/swc-win32-x64-msvc': 14.2.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
-
-  next@14.2.5(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.5(@babel/core@7.25.7)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.5
       '@swc/helpers': 0.5.5
@@ -17156,6 +17167,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.1.1
+
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.1.1
@@ -17171,6 +17186,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   p-map@2.1.0: {}
 
@@ -17244,6 +17263,8 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
+
+  path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -18955,6 +18976,8 @@ snapshots:
       ohash: 1.1.4
       pathe: 1.1.2
       ufo: 1.5.4
+
+  unicorn-magic@0.1.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
This PR takes care of the following:

- Deploy single doc to a memory on langbase using 

```sh
npx baseai deploy -m <memory-name> -d <doc-name>
```
- If doc doesn't exist in prod, we upload the doc in memory
- If doc exists in prod, we exit the process and ask user to run the same command with `-o` overwrite flag
- Add deploy a doc to memory [docs](https://saad-deploy-documents.baseai-291.pages.dev/docs/deployment/document)

### Doc doesn't exist in prod

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/b8825a71-7ead-4229-bf29-c4e464ebe983">

### Doc exists in prod

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/191d2317-f6d5-47cd-915e-999ed0d63a33">

### Overwrite existing doc

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/72306d32-fa4a-43fa-a5f2-db7be305782a">

