### PR TITLE
🐛 FIX: Default config for non-git-sync memory

### DIFF
--- a/packages/baseai/src/memory/create.ts
+++ b/packages/baseai/src/memory/create.ts
@@ -63,8 +63,8 @@ export async function createMemory() {
 		}
 	);
 
-	let memoryFilesDir = '';
-	let fileExtensions: string[] = [];
+	let memoryFilesDir = '.';
+	let fileExtensions: string[] = ['*'];
 
 	if (memoryInfo.useGitRepo) {
 		// Check if the current directory is a Git repository


### PR DESCRIPTION
Fixes default value of fileExtensions to `['*']` and dirToTrack to `.`, otherwise config validation fails. 