### PR TITLE
📦 NEW: TogetherAI tool call support

### DIFF
--- a/packages/baseai/src/dev/llms/call-together.ts
+++ b/packages/baseai/src/dev/llms/call-together.ts
@@ -4,6 +4,7 @@ import { GROQ } from '../data/models';
 import { applyJsonModeIfEnabled, handleLlmError } from './utils';
 import type { Message } from 'types/pipe';
 import type { ModelParams } from 'types/providers';
+import { addToolsToParams } from '../utils/add-tools-to-params';
 
 export async function callTogether({
 	pipe,
@@ -28,6 +29,7 @@ export async function callTogether({
 		// Together behaves weirdly with stop value. Omitting it.
 		delete modelParams['stop'];
 		applyJsonModeIfEnabled(modelParams, pipe);
+		addToolsToParams(modelParams, pipe);
 		dlog('modelParams', modelParams);
 
 		return await together.chat.completions.create(modelParams as any);


### PR DESCRIPTION
This PR adds tool call support to the following TogetherAI models:

- meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo
- meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
- meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo
- mistralai/Mistral-7B-Instruct-v0.1
- mistralai/Mixtral-8x7B-Instruct-v0.1