### PR TITLE
📦 NEW: Handle gitignored files in git repo memory

### DIFF
--- a/packages/baseai/src/utils/memory/git-sync/handle-git-sync-memories.ts
+++ b/packages/baseai/src/utils/memory/git-sync/handle-git-sync-memories.ts
@@ -58,7 +58,8 @@ export async function handleGitSyncMemories({
 
 	const allFilesWithContent = await loadMemoryFilesFromCustomDir({
 		memoryName,
-		memoryConfig: config
+		memoryConfig: config,
+		useGitRepo: true
 	});
 
 	const allFiles = allFilesWithContent.map(file => file.name);

--- a/packages/baseai/src/utils/memory/git-sync/handle-git-sync-memories.ts
+++ b/packages/baseai/src/utils/memory/git-sync/handle-git-sync-memories.ts
@@ -58,8 +58,7 @@ export async function handleGitSyncMemories({
 
 	const allFilesWithContent = await loadMemoryFilesFromCustomDir({
 		memoryName,
-		memoryConfig: config,
-		useGitRepo: true
+		memoryConfig: config
 	});
 
 	const allFiles = allFilesWithContent.map(file => file.name);

--- a/packages/baseai/src/utils/memory/load-memory-files.ts
+++ b/packages/baseai/src/utils/memory/load-memory-files.ts
@@ -45,12 +45,10 @@ export const loadMemoryFiles = async (
  */
 export const loadMemoryFilesFromCustomDir = async ({
 	memoryName,
-	memoryConfig,
-	useGitRepo
+	memoryConfig
 }: {
 	memoryName: string;
 	memoryConfig: MemoryConfigI;
-	useGitRepo?: boolean;
 }): Promise<MemoryDocumentI[]> => {
 	const memoryFilesPath = memoryConfig.dirToTrack;
 
@@ -67,15 +65,11 @@ export const loadMemoryFilesFromCustomDir = async ({
 
 	let allFiles: string[];
 	try {
-		if (useGitRepo) {
-			allFiles = execSync(`git ls-files ${memoryFilesPath}`, {
-				encoding: 'utf-8'
-			})
-				.split('\n')
-				.filter(Boolean);
-		} else {
-			allFiles = await traverseDirectory(memoryFilesPath);
-		}
+		allFiles = execSync(`git ls-files ${memoryFilesPath}`, {
+			encoding: 'utf-8'
+		})
+			.split('\n')
+			.filter(Boolean);
 	} catch (error) {
 		p.cancel(`Failed to read documents in memory '${memoryName}'.`);
 		process.exit(1);

--- a/packages/baseai/src/utils/memory/load-memory-files.ts
+++ b/packages/baseai/src/utils/memory/load-memory-files.ts
@@ -6,6 +6,7 @@ import { getDocumentContent } from './get-document-content';
 import { formatDocSize } from './lib';
 import loadMemoryConfig from './load-memory-config';
 import { memoryConfigSchema, type MemoryConfigI } from 'types/memory';
+import { execSync } from 'child_process';
 
 export interface MemoryDocumentI {
 	name: string;
@@ -44,10 +45,12 @@ export const loadMemoryFiles = async (
  */
 export const loadMemoryFilesFromCustomDir = async ({
 	memoryName,
-	memoryConfig
+	memoryConfig,
+	useGitRepo
 }: {
 	memoryName: string;
 	memoryConfig: MemoryConfigI;
+	useGitRepo?: boolean;
 }): Promise<MemoryDocumentI[]> => {
 	const memoryFilesPath = memoryConfig.dirToTrack;
 
@@ -64,7 +67,15 @@ export const loadMemoryFilesFromCustomDir = async ({
 
 	let allFiles: string[];
 	try {
-		allFiles = await traverseDirectory(memoryFilesPath);
+		if (useGitRepo) {
+			allFiles = execSync(`git ls-files ${memoryFilesPath}`, {
+				encoding: 'utf-8'
+			})
+				.split('\n')
+				.filter(Boolean);
+		} else {
+			allFiles = await traverseDirectory(memoryFilesPath);
+		}
 	} catch (error) {
 		p.cancel(`Failed to read documents in memory '${memoryName}'.`);
 		process.exit(1);


### PR DESCRIPTION
This PR handles git ignored files in git repo memories.

Previously, deploying the repo with root path selected included git ignored files like the `node_modules` folder. This PR fixes it and properly ignores those files.

<img width="1513" alt="Screenshot 2024-10-15 at 6 41 42 PM" src="https://github.com/user-attachments/assets/39e61133-7aa8-43fb-95e2-0585d4fcbec1">
