### PR TITLE
🐛 FIX: Overwrite message types

### DIFF
--- a/packages/core/src/pipes/pipes.ts
+++ b/packages/core/src/pipes/pipes.ts
@@ -1,32 +1,10 @@
 import type {Runner} from 'src/helpers';
-import {Pipe as PipeI} from '../../types/pipes';
+import {Message, MessageRole, Pipe as PipeI, ToolCall} from '../../types/pipes';
 import {Request} from '../common/request';
 import {getLLMApiKey} from '../utils/get-llm-api-key';
 import {getApiUrl, isProd} from '../utils/is-prod';
 import {toOldPipeFormat} from '../utils/to-old-pipe-format';
 import {isLocalServerRunning} from 'src/utils/local-server-running';
-
-// Type Definitions
-export type Role = 'user' | 'assistant' | 'system' | 'tool';
-
-export interface Function {
-	name: string;
-	arguments: string;
-}
-
-export interface ToolCall {
-	id: string;
-	type: 'function';
-	function: Function;
-}
-
-export interface Message {
-	role: Role;
-	content: string | null;
-	name?: string;
-	tool_call_id?: string;
-	tool_calls?: ToolCall[];
-}
 
 export interface Variable {
 	name: string;
@@ -137,7 +115,7 @@ export class Pipe {
 
 			return {
 				tool_call_id: toolCall.id,
-				role: 'tool' as Role,
+				role: 'tool' as MessageRole,
 				name: toolName,
 				content: JSON.stringify(toolResponse),
 			};
@@ -330,7 +308,7 @@ interface ChoiceStream {
 }
 
 interface Delta {
-	role?: Role;
+	role?: MessageRole;
 	content?: string;
 	tool_calls?: ToolCall[];
 }

--- a/packages/core/src/react/use-pipe.ts
+++ b/packages/core/src/react/use-pipe.ts
@@ -116,7 +116,7 @@ export function usePipe({
 	);
 
 	const sendRequest = useCallback(
-		async (content: string, options: PipeRequestOptions = {}) => {
+		async (content: string | null, options: PipeRequestOptions = {}) => {
 			abortControllerRef.current = new AbortController();
 			const {signal} = abortControllerRef.current;
 
@@ -127,7 +127,8 @@ export function usePipe({
 
 				let updatedMessages = messagesRef.current;
 
-				if (content.trim()) {
+				const hasContent = content && content.trim();
+				if (hasContent) {
 					// Add new user message only if content is not empty
 					updatedMessages = [
 						...messagesRef.current,

--- a/packages/core/types/pipes.ts
+++ b/packages/core/types/pipes.ts
@@ -10,12 +10,26 @@ import {
 	PerplexityModels,
 	TogetherModels,
 } from './model';
+
 export type MessageRole = 'function' | 'assistant' | 'system' | 'user' | 'tool';
+
+export interface Function {
+	name: string;
+	arguments: string;
+}
+
+export interface ToolCall {
+	id: string;
+	type: 'function';
+	function: Function;
+}
 
 export interface Message {
 	role: MessageRole;
-	content: string;
+	content: string | null;
 	name?: string;
+	tool_call_id?: string;
+	tool_calls?: ToolCall[];
 }
 
 interface ToolFunction {


### PR DESCRIPTION
We currently have different `Message` types inside `core/src/pipes/pipes.ts` and `core/types/pipes.ts`. This leads to issue with `usePipe` hook. 

The hook internally uses `Message` type from `core/types/pipes.ts`. Whereas the available exported `Message` type from the package is from `core/src/pipes/pipes.ts` (type getting overwritten here). This leads to type mismatch when user passes `messages` from usePipe down a component via props in a TS file.

This PR unifies different `Message` types and uses it inside `usePipe` hook so the correct type is exported from the package.