### PR TITLE
🐛 FIX: Message order when memory attached

### DIFF
--- a/packages/baseai/src/utils/memory/lib.ts
+++ b/packages/baseai/src/utils/memory/lib.ts
@@ -155,7 +155,9 @@ export const addContextFromMemory = async ({
 		if (!isMemoryAttached || !messagesExist) return;
 
 		// This will be the user prompt.
-		const lastUserMsg = messages.reverse().find(m => m.role === 'user');
+		const lastUserMsg = [...messages]
+			.reverse()
+			.find(m => m.role === 'user');
 		const userPrompt = lastUserMsg?.content;
 
 		// If there is no user prompt, return the messages.


### PR DESCRIPTION
If a pipe has a memory, the messages array gets reversed that results in first message being used as the latest message for LLM. This PR fixes it.

## Before

<img width="527" alt="image" src="https://github.com/user-attachments/assets/81e0d352-363b-44e5-aa02-904f4d990cc7">

<img width="653" alt="image" src="https://github.com/user-attachments/assets/32f81b82-27a6-4f5d-8c13-95f2a65ff5c8">

## After

<img width="508" alt="image" src="https://github.com/user-attachments/assets/2ef23221-2482-431e-ae66-dc0fa6184f5c">

