### PR TITLE
🐛 FIX: stream type of RunOptionsStream

### DIFF
--- a/packages/core/src/pipes/pipes.ts
+++ b/packages/core/src/pipes/pipes.ts
@@ -19,7 +19,7 @@ export interface RunOptions {
 }
 
 export interface RunOptionsStream extends RunOptions {
-	stream: true;
+	stream: boolean;
 }
 
 export interface Usage {


### PR DESCRIPTION
Fixed the stream type for the RunOptionsStream to `boolean` from `true`