### PR TITLE
📦 NEW: Export helper functions

### DIFF
--- a/packages/core/src/common/request.ts
+++ b/packages/core/src/common/request.ts
@@ -1,4 +1,4 @@
-import {Stream} from 'openai/streaming';
+import {handleResponseStream} from 'src/helpers';
 import {APIConnectionError, APIError} from './errors';
 
 interface RequestOptions {
@@ -64,7 +64,7 @@ export class Request {
 		const threadId = response.headers.get('lb-thread-id');
 
 		if (options.body?.stream) {
-			return this.handleRunResponseStream({
+			return handleResponseStream({
 				response,
 				rawResponse: options.body.rawResponse,
 			}) as T;
@@ -126,42 +126,6 @@ export class Request {
 			response.statusText,
 			Object.fromEntries(response.headers.entries()),
 		);
-	}
-
-	private handleRunResponseStream({
-		response,
-		rawResponse,
-	}: {
-		response: Response;
-		rawResponse?: boolean;
-	}): {
-		stream: any;
-		threadId: string | null;
-		rawResponse?: {
-			headers: Record<string, string>;
-		};
-	} {
-		const controller = new AbortController();
-		// const stream = Stream.fromSSEResponse(response, controller);
-		const streamSSE = Stream.fromSSEResponse(response, controller);
-		const stream = streamSSE.toReadableStream();
-
-		const result: {
-			stream: ReadableStream<any>;
-			threadId: string | null;
-			rawResponse?: {
-				headers: Record<string, string>;
-			};
-		} = {
-			stream,
-			threadId: response.headers.get('lb-thread-id'),
-		};
-		if (rawResponse) {
-			result.rawResponse = {
-				headers: Object.fromEntries(response.headers.entries()),
-			};
-		}
-		return result;
 	}
 
 	private async handleRunResponse({

--- a/packages/core/src/helpers/stream.ts
+++ b/packages/core/src/helpers/stream.ts
@@ -1,5 +1,6 @@
 import {ChatCompletionStream} from 'openai/lib/ChatCompletionStream';
 import {ChunkStream} from 'src/pipes';
+import {Stream} from 'openai/streaming';
 
 export interface Runner extends ChatCompletionStream<null> {}
 
@@ -32,3 +33,51 @@ export const getRunner = (readableStream: ReadableStream) => {
 export const getTextPart = (chunk: ChunkStream) => {
 	return chunk.choices[0]?.delta?.content || '';
 };
+
+/**
+ * Handles the response stream from a given `Response` object.
+ *
+ * @param {Object} params - The parameters for handling the response stream.
+ * @param {Response} params.response - The API response to handle.
+ * @param {boolean} params.rawResponse - Optional flag to include raw response headers.
+ *
+ * @returns {Object} An object containing the processed stream, thread ID, and optionally raw response headers.
+ * @returns {ReadableStream<any>} return.stream - The readable stream created from the response.
+ * @returns {string | null} return.threadId - The thread ID extracted from the response headers.
+ * @returns {Object} [return.rawResponse] - Optional raw response headers.
+ * @returns {Record<string, string>} return.rawResponse.headers - The headers from the raw response.
+ */
+export function handleResponseStream({
+	response,
+	rawResponse,
+}: {
+	response: Response;
+	rawResponse?: boolean;
+}): {
+	stream: any;
+	threadId: string | null;
+	rawResponse?: {
+		headers: Record<string, string>;
+	};
+} {
+	const controller = new AbortController();
+	const streamSSE = Stream.fromSSEResponse(response, controller);
+	const stream = streamSSE.toReadableStream();
+
+	const result: {
+		stream: ReadableStream<any>;
+		threadId: string | null;
+		rawResponse?: {
+			headers: Record<string, string>;
+		};
+	} = {
+		stream,
+		threadId: response.headers.get('lb-thread-id'),
+	};
+	if (rawResponse) {
+		result.rawResponse = {
+			headers: Object.fromEntries(response.headers.entries()),
+		};
+	}
+	return result;
+}

--- a/packages/core/src/react/use-pipe.ts
+++ b/packages/core/src/react/use-pipe.ts
@@ -263,6 +263,7 @@ export function usePipe({
 			setMessages: updateMessages,
 			threadId: threadIdRef.current,
 			sendMessage,
+			setInput,
 		}),
 		[
 			messages,


### PR DESCRIPTION
This PR takes care of the following:

- Export `setInput` from `usePipe` to directly set the state
- Export `handleStreamResponse` to process LB prod API stream