### PR TITLE
🐛 FIX: BaseAI deploy spinner not stopped

### DIFF
--- a/packages/baseai/src/deploy/index.ts
+++ b/packages/baseai/src/deploy/index.ts
@@ -422,6 +422,7 @@ export async function readMemoryDirectory({
 	spinner.start('Reading memory directory');
 	try {
 		const memory = await fs.readdir(memoryDir);
+		spinner.stop();
 		return memory;
 	} catch (error) {
 		handleDirectoryReadError({ spinner, dir: memoryDir, error });


### PR DESCRIPTION
This PR fixes the following where spinner does not stop on BaseAI deploy that leads to CLI not exiting correctly.

![image](https://github.com/user-attachments/assets/9feaac1f-8471-4ff0-a075-bb279c398042)
