### PR TITLE
📦 NEW: `runTools` run options param in pipe.run()

### DIFF
--- a/packages/core/src/pipes/pipes.ts
+++ b/packages/core/src/pipes/pipes.ts
@@ -16,6 +16,7 @@ export interface RunOptions {
 	variables?: Variable[];
 	threadId?: string;
 	rawResponse?: boolean;
+	runTool?: boolean;
 }
 
 export interface RunOptionsStream extends RunOptions {
@@ -175,10 +176,9 @@ export class Pipe {
 			return {} as RunResponse | RunResponseStream;
 		}
 
-		// logger('pipe.run.response');
-		// logger(response, {depth: null, colors: true});
+		const runTool = options.runTool ?? true;
 
-		if (stream) {
+		if (stream || !runTool) {
 			return response as RunResponseStream;
 		}
 

--- a/packages/core/src/pipes/pipes.ts
+++ b/packages/core/src/pipes/pipes.ts
@@ -167,6 +167,9 @@ export class Pipe {
 		const stream = this.hasTools ? false : requestedStream;
 		this.warnIfToolsWithStream(requestedStream);
 
+		const runTools = options.runTools ?? true;
+		delete options.runTools;
+
 		const body = {...options, stream};
 
 		let response = await this.createRequest<
@@ -175,8 +178,6 @@ export class Pipe {
 		if (Object.entries(response).length === 0) {
 			return {} as RunResponse | RunResponseStream;
 		}
-
-		const runTools = options.runTools ?? true;
 
 		if (stream || !runTools) {
 			return response as RunResponseStream;

--- a/packages/core/src/pipes/pipes.ts
+++ b/packages/core/src/pipes/pipes.ts
@@ -16,7 +16,7 @@ export interface RunOptions {
 	variables?: Variable[];
 	threadId?: string;
 	rawResponse?: boolean;
-	runTool?: boolean;
+	runTools?: boolean;
 }
 
 export interface RunOptionsStream extends RunOptions {
@@ -176,9 +176,9 @@ export class Pipe {
 			return {} as RunResponse | RunResponseStream;
 		}
 
-		const runTool = options.runTool ?? true;
+		const runTools = options.runTools ?? true;
 
-		if (stream || !runTool) {
+		if (stream || !runTools) {
 			return response as RunResponseStream;
 		}
 


### PR DESCRIPTION
This PR allows user to intercept tool call instead of executing it by default. 