### PR TITLE
📦 NEW: `setThreadId` function in usePipe

### DIFF
--- a/packages/core/src/react/use-pipe.ts
+++ b/packages/core/src/react/use-pipe.ts
@@ -24,6 +24,7 @@ interface UsePipeOptions {
 }
 
 const uuidSchema = z.string().uuid();
+const externalThreadIdSchema = uuidSchema.optional();
 
 export function usePipe({
 	apiRoute = '/langbase/pipes/run-stream',
@@ -86,6 +87,17 @@ export function usePipe({
 		},
 		[updateMessages, onResponse, onFinish],
 	);
+
+	const setThreadId = useCallback((newThreadId: string) => {
+		const isValidThreadId =
+			externalThreadIdSchema.safeParse(newThreadId).success;
+
+		if (isValidThreadId) {
+			threadIdRef.current = newThreadId;
+		} else {
+			throw new Error('Invalid thread ID');
+		}
+	}, []);
 
 	const getMessagesToSend = useCallback(
 		(updatedMessages: Message[]): [Message[], boolean] => {
@@ -264,6 +276,7 @@ export function usePipe({
 			threadId: threadIdRef.current,
 			sendMessage,
 			setInput,
+			setThreadId,
 		}),
 		[
 			messages,

--- a/packages/core/src/react/use-pipe.ts
+++ b/packages/core/src/react/use-pipe.ts
@@ -42,7 +42,9 @@ export function usePipe({
 	const [error, setError] = useState<Error | null>(null);
 
 	const abortControllerRef = useRef<AbortController | null>(null);
-	const threadIdRef = useRef<string | null>(initialThreadId || null);
+	const threadIdRef = useRef<string | undefined>(
+		initialThreadId || undefined,
+	);
 	const messagesRef = useRef<Message[]>(initialMessages);
 	const isFirstRequestRef = useRef<boolean>(true);
 
@@ -88,7 +90,7 @@ export function usePipe({
 		[updateMessages, onResponse, onFinish],
 	);
 
-	const setThreadId = useCallback((newThreadId: string) => {
+	const setThreadId = useCallback((newThreadId: string | undefined) => {
 		const isValidThreadId =
 			externalThreadIdSchema.safeParse(newThreadId).success;
 


### PR DESCRIPTION
This PR adds a new `setThreadId` function in usePipe hook to set custom thread id.