### PR TITLE
📦 NEW: Remove default request timeout

### DIFF
--- a/packages/core/src/common/request.ts
+++ b/packages/core/src/common/request.ts
@@ -103,7 +103,9 @@ export class Request {
 			method: options.method,
 			headers,
 			body: JSON.stringify(options.body),
-			signal: AbortSignal.timeout(this.config.timeout || 30000),
+			...(this.config.timeout && {
+				signal: AbortSignal.timeout(this.config.timeout),
+			}),
 		});
 		return resp;
 	}


### PR DESCRIPTION
This PR dynamically timeouts request if there `this.config.timeout` exists. This will prevent timing out request when response takes longer than 30s. 