### PR TITLE
🐛 FIX: Handle special characters in description

### DIFF
--- a/packages/baseai/src/memory/create.ts
+++ b/packages/baseai/src/memory/create.ts
@@ -137,7 +137,7 @@ import path from 'path';
 
 const ${memoryNameCamelCase} = (): MemoryI => ({
   name: '${memoryNameSlugified}',
-  description: '${memoryInfo.description || ''}',
+  description: ${JSON.stringify(memoryInfo.description) || ''},
   config: {
 		useGitRepo: ${memoryInfo.useGitRepo},
 		dirToTrack: path.posix.join(${memoryFilesDir

--- a/packages/baseai/src/pipe/index.ts
+++ b/packages/baseai/src/pipe/index.ts
@@ -38,7 +38,7 @@ export async function createPipe() {
 			name: () =>
 				p.text({
 					message: 'Name of the pipe',
-					placeholder: 'AI Pipe Agent',
+					placeholder: 'ai-agent-pipe',
 					validate: value => {
 						const result = pipeNameSchema.safeParse(value);
 						if (!result.success) {
@@ -135,7 +135,7 @@ const ${pipeNameCamelCase} = (): PipeI => ({
     // Replace with your API key https://langbase.com/docs/api-reference/api-keys
 	apiKey: process.env.LANGBASE_API_KEY!,
     name: '${pipeNameSlugified}',
-    description: '${pipeInfo.description || ''}',
+    description: ${JSON.stringify(pipeInfo.description) || ''},
     status: '${pipeInfo.status}',
     model: 'openai:gpt-4o-mini',
     stream: true,

--- a/packages/baseai/src/tool/index.ts
+++ b/packages/baseai/src/tool/index.ts
@@ -110,7 +110,7 @@ const ${camelCaseNameToolName} = (): ToolI => ({
 	type: 'function' as const,
 	function: {
 		name: '${camelCaseNameToolName}',
-		description: '${description}',
+		description: ${JSON.stringify(description) || ''},
 		parameters: {},
 	},
 });


### PR DESCRIPTION
BaseAI CLI breaks when user provides a special character in pipe, memory or tool description when creating any of them. This PR fixes it.