### PR TITLE
📦 NEW: Allow empty submit

### DIFF
--- a/packages/core/src/react/use-pipe.ts
+++ b/packages/core/src/react/use-pipe.ts
@@ -155,8 +155,8 @@ export function usePipe({
 				const [messagesToSend, lastMessageOnly] =
 					getMessagesToSend(updatedMessages);
 
-				// Ensure there's at least one message to send
-				if (messagesToSend.length === 0) {
+				// Ensure there's at least one message to send if not allowing empty submit
+				if (messagesToSend.length === 0 && !options.allowEmptySubmit) {
 					throw new Error(
 						'At least one message or initial message is required',
 					);


### PR DESCRIPTION
This PR adds empty submit functionality, which let's users send the request with empty/no message. 

This is handled by a `allowEmptySubmit` flag in RunOptions which is false by default. 

Example usage with usePipe: 

```ts
const options = {body, headers, allowEmptySubmit: true}

handleSubmit(e, options);
```