### PR TITLE
📦 NEW: Params for pipe.run() sdk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+****<p align="center">
   <a href="https://baseai.dev">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/LangbaseInc/docs-images/refs/heads/main/baseai/baseai-cover.png">


### PR DESCRIPTION
This PR adds params in `pipe.run()` so it can be used in Langbase SDK.