### PR TITLE
📦 NEW: Use Langbase API key from .env file to deploy

### DIFF
--- a/packages/baseai/package.json
+++ b/packages/baseai/package.json
@@ -60,7 +60,6 @@
 		"cli-table3": "^0.6.5",
 		"cli-welcome": "^3.0.0",
 		"compute-cosine-similarity": "^1.1.0",
-		"conf": "^13.0.1",
 		"cosmiconfig": "^9.0.0",
 		"cosmiconfig-typescript-loader": "^5.0.0",
 		"dotenv": "^16.4.5",

--- a/packages/baseai/src/deploy/document.ts
+++ b/packages/baseai/src/deploy/document.ts
@@ -7,9 +7,7 @@ import {
 	handleError,
 	handleInvalidConfig,
 	listMemoryDocuments,
-	retrieveAuthentication,
 	uploadDocumentsToMemory,
-	type Account
 } from '.';
 import path from 'path';
 import fs from 'fs/promises';
@@ -21,6 +19,7 @@ import {
 } from '@/utils/memory/load-memory-files';
 import type { MemoryI } from 'types/memory';
 import { compareDocumentLists } from '@/utils/memory/compare-docs-list';
+import { retrieveAuthentication, type Account } from '@/utils/retrieve-credentials';
 
 type Spinner = ReturnType<typeof p.spinner>;
 

--- a/packages/baseai/src/deploy/index.ts
+++ b/packages/baseai/src/deploy/index.ts
@@ -18,7 +18,6 @@ import path from 'path';
 import color from 'picocolors';
 import { type MemoryI } from 'types/memory';
 import type { Pipe, PipeOld } from 'types/pipe';
-import { getStoredAuth } from './../auth/index';
 import {
 	handleGitSyncMemories,
 	updateDeployedCommitHash
@@ -28,11 +27,10 @@ import {
 	generateUpgradeInstructions,
 	isOldMemoryConfigFormat
 } from '@/utils/memory/handle-old-memory-config';
-
-export interface Account {
-	login: string;
-	apiKey: string;
-}
+import {
+	retrieveAuthentication,
+	type Account
+} from '@/utils/retrieve-credentials';
 
 interface ErrorResponse {
 	error?: { message: string };
@@ -157,26 +155,6 @@ async function readToolsDirectory({
 		return tools;
 	} catch (error) {
 		handleDirectoryReadError({ spinner, dir: toolsDir, error });
-		return null;
-	}
-}
-
-export async function retrieveAuthentication({
-	spinner
-}: {
-	spinner: Spinner;
-}): Promise<Account | null> {
-	spinner.start('Retrieving stored authentication');
-	try {
-		const account = await getStoredAuth();
-		if (!account) {
-			handleNoAccountFound({ spinner });
-			return null;
-		}
-		spinner.stop(`Deploying as ${color.cyan(account.login)}`);
-		return account;
-	} catch (error) {
-		handleAuthError({ spinner, error });
 		return null;
 	}
 }
@@ -355,23 +333,6 @@ function handleDirectoryReadError({
 	} else {
 		p.log.error(`Error reading directory: ${(error as Error).message}`);
 	}
-}
-
-function handleNoAccountFound({ spinner }: { spinner: Spinner }): void {
-	spinner.stop('No account found');
-	p.log.warn('No account found. Please authenticate first.');
-	p.log.info(`Run: ${color.green('npx baseai auth')}`);
-}
-
-function handleAuthError({
-	spinner,
-	error
-}: {
-	spinner: Spinner;
-	error: unknown;
-}): void {
-	spinner.stop('Failed to retrieve authentication');
-	p.log.error(`Error retrieving stored auth: ${(error as Error).message}`);
 }
 
 export function handleInvalidConfig({
@@ -929,11 +890,6 @@ async function getSignedUploadUrl({
 		memoryName
 	});
 
-	const isOrgAccount = account.apiKey.includes(':');
-
-	const ownerLogin = isOrgAccount
-		? account.apiKey.split(':')[0]
-		: account.login;
 	try {
 		const response = await fetch(uploadDocument, {
 			method: 'POST',
@@ -943,7 +899,6 @@ async function getSignedUploadUrl({
 			},
 			body: JSON.stringify({
 				memoryName,
-				ownerLogin,
 				fileName: documentName
 			})
 		});
@@ -1180,10 +1135,10 @@ export async function deploySingleMemory({
 		// Retrieve authentication
 		const account = await retrieveAuthentication({ spinner });
 		if (!account) {
-			p.log.error(
-				'Authentication failed. Please run "npx baseai auth" to authenticate.'
+			p.outro(
+				`No account found. Skipping deployment. \n Run: ${cyan('npx baseai@latest auth')}`
 			);
-			return;
+			process.exit(1);
 		}
 
 		// Call deployMemory function

--- a/packages/baseai/src/utils/retrieve-credentials.ts
+++ b/packages/baseai/src/utils/retrieve-credentials.ts
@@ -1,0 +1,59 @@
+import { loadConfig } from './config/config-handler';
+import fs from 'fs/promises';
+import * as p from '@clack/prompts';
+import color from 'picocolors';
+
+export interface Account {
+	apiKey: string;
+}
+
+type Spinner = ReturnType<typeof p.spinner>;
+
+function handleNoAccountFound({ spinner }: { spinner: Spinner }): void {
+	spinner.stop('No account found');
+	p.log.warn('No account found. Please authenticate first.');
+	p.log.info(`Run: ${color.green('npx baseai auth')}`);
+}
+function handleAuthError({
+	spinner,
+	error
+}: {
+	spinner: Spinner;
+	error: unknown;
+}): void {
+	spinner.stop('Failed to retrieve authentication');
+	p.log.error(`Error retrieving stored auth: ${(error as Error).message}`);
+}
+
+export async function retrieveAuthentication({
+	spinner
+}: {
+	spinner: Spinner;
+}): Promise<Account | null> {
+	spinner.start('Retrieving stored authentication');
+	try {
+		const baiConfig = await loadConfig();
+		let envFile = baiConfig.envFilePath || '.env';
+		const envFileContent = await fs.readFile(envFile, 'utf-8');
+
+		const apiKey = envFileContent
+			.split('\n')
+			.reverse()
+			.find(line => line.includes('LANGBASE_API_KEY='))
+			?.split('=')[1];
+
+		if (!apiKey) {
+			handleNoAccountFound({ spinner });
+			return null;
+		}
+
+		spinner.stop('Retrieved stored authentication');
+
+		return {
+			apiKey
+		};
+	} catch (error) {
+		handleAuthError({ spinner, error });
+		return null;
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,9 +551,6 @@ importers:
       compute-cosine-similarity:
         specifier: ^1.1.0
         version: 1.1.0
-      conf:
-        specifier: ^13.0.1
-        version: 13.0.1
       cosmiconfig:
         specifier: ^9.0.0
         version: 9.0.0(typescript@5.6.2)


### PR DESCRIPTION
This PR includes the following changes:

- `npx baseai auth` now only saves/updates API key in `.env` file
  - If key exists already then we ask user if they want to overwrite.
- `npx baseai deploy` use Langbase API key from `.env` file instead of global config