### PR TITLE
📦 NEW: Dynamically set document metadata

### DIFF
--- a/examples/nodejs/baseai/memory/ai-agent-memory/index.ts
+++ b/examples/nodejs/baseai/memory/ai-agent-memory/index.ts
@@ -10,11 +10,13 @@ const memoryAiAgentMemory = (): MemoryI => ({
 		deployedAt: '',
 		embeddedAt: '',
 	},
-	document: {
+	documents: {
 		meta: doc => {
+			// generate a URL for each document
+			const url = `https://example.com/${doc.path}`;
 			return {
+				url,
 				name: doc.name,
-				path: doc.path,
 			};
 		},
 	},

--- a/examples/nodejs/baseai/memory/ai-agent-memory/index.ts
+++ b/examples/nodejs/baseai/memory/ai-agent-memory/index.ts
@@ -10,6 +10,14 @@ const memoryAiAgentMemory = (): MemoryI => ({
 		deployedAt: '',
 		embeddedAt: '',
 	},
+	document: {
+		meta: doc => {
+			return {
+				name: doc.name,
+				path: doc.path,
+			};
+		},
+	},
 });
 
 export default memoryAiAgentMemory;

--- a/packages/baseai/src/deploy/index.ts
+++ b/packages/baseai/src/deploy/index.ts
@@ -689,7 +689,8 @@ export async function uploadDocumentsToMemory({
 			const signedUrl = await getSignedUploadUrl({
 				documentName: doc.name,
 				memoryName: name,
-				account
+				account,
+				meta: doc.meta
 			});
 
 			const uploadResponse = await uploadDocument(signedUrl, doc.blob);
@@ -919,11 +920,13 @@ export async function listMemoryDocuments({
 async function getSignedUploadUrl({
 	documentName,
 	memoryName,
-	account
+	account,
+	meta
 }: {
 	documentName: string;
 	memoryName: string;
 	account: Account;
+	meta: Record<string, string>;
 }): Promise<string> {
 	const { uploadDocument } = getMemoryApiUrls({
 		memoryName
@@ -942,6 +945,7 @@ async function getSignedUploadUrl({
 				Authorization: `Bearer ${account.apiKey}`
 			},
 			body: JSON.stringify({
+				meta,
 				memoryName,
 				ownerLogin,
 				fileName: documentName

--- a/packages/baseai/src/utils/memory/load-memory-files.ts
+++ b/packages/baseai/src/utils/memory/load-memory-files.ts
@@ -30,11 +30,11 @@ export const loadMemoryFiles = async (
 
 	// useDocumentsDir
 	const useDocumentsDir = !memoryConfig || !memoryConfig.git.enabled;
-	const documentMeta = memoryConfig?.document;
+	const documentConfig = memoryConfig?.documents;
 
 	// Load files from documents directory.
 	if (useDocumentsDir) {
-		return await loadMemoryFilesFromDocsDir({ memoryName, documentMeta });
+		return await loadMemoryFilesFromDocsDir({ memoryName, documentConfig });
 	}
 
 	// Load files from the repo.
@@ -138,8 +138,8 @@ export const loadMemoryFilesFromCustomDir = async ({
 
 			let meta = {};
 
-			if (memoryConfig?.document?.meta) {
-				meta = memoryConfig.document.meta(memoryFile) || {};
+			if (memoryConfig?.documents?.meta) {
+				meta = memoryConfig.documents.meta(memoryFile) || {};
 			}
 
 			return { ...memoryFile, meta };
@@ -177,10 +177,10 @@ export const loadMemoryFilesFromCustomDir = async ({
  */
 export const loadMemoryFilesFromDocsDir = async ({
 	memoryName,
-	documentMeta
+	documentConfig
 }: {
 	memoryName: string;
-	documentMeta?: DocumentConfigI;
+	documentConfig?: DocumentConfigI;
 }): Promise<MemoryDocumentI[]> => {
 	const memoryDir = path.join(process.cwd(), 'baseai', 'memory', memoryName);
 	const memoryFilesPath = path.join(memoryDir, 'documents');
@@ -244,8 +244,8 @@ export const loadMemoryFilesFromDocsDir = async ({
 
 			let meta = {};
 
-			if (documentMeta?.meta) {
-				meta = documentMeta.meta(memoryFile) || {};
+			if (documentConfig?.meta) {
+				meta = documentConfig.meta(memoryFile) || {};
 			}
 
 			return { ...memoryFile, meta };

--- a/packages/baseai/types/memory.ts
+++ b/packages/baseai/types/memory.ts
@@ -27,14 +27,32 @@ export const gitConfigSchema = z.object({
 	embeddedAt: z.string().trim().optional().default('')
 });
 
+export const documentSchema = z.object({
+	meta: z
+		.function()
+		.args(
+			z.object({
+				name: z.string(),
+				size: z.string(),
+				content: z.string(),
+				blob: z.instanceof(Blob),
+				path: z.string(),
+			})
+		)
+		.returns(z.record(z.string()))
+		.optional()
+});
+
 export const memoryConfigSchema = z.object({
 	name: z.string(),
 	description: z.string().optional(),
-	git: gitConfigSchema
+	git: gitConfigSchema,
+	document: documentSchema.optional()
 });
 
 export type GitConfigI = z.infer<typeof gitConfigSchema>;
 
 export type MemoryConfigI = z.infer<typeof memoryConfigSchema>;
+export type DocumentConfigI = z.infer<typeof documentSchema>;
 
 export type MemoryI = MemoryConfigI;

--- a/packages/baseai/types/memory.ts
+++ b/packages/baseai/types/memory.ts
@@ -47,7 +47,7 @@ export const memoryConfigSchema = z.object({
 	name: z.string(),
 	description: z.string().optional(),
 	git: gitConfigSchema,
-	document: documentSchema.optional()
+	documents: documentSchema.optional()
 });
 
 export type GitConfigI = z.infer<typeof gitConfigSchema>;

--- a/packages/core/types/memory.ts
+++ b/packages/core/types/memory.ts
@@ -6,8 +6,22 @@ export interface GitConfig {
 	embeddedAt?: string;
 }
 
+export interface MemoryDocumentI {
+	name: string;
+	size: string;
+	content: string;
+	blob: Blob;
+	path: string;
+	originalName: string;
+}
+
+export interface Document {
+	meta?: (documnet: MemoryDocumentI) => Record<string, string>;
+}
+
 export interface Memory {
 	name: string;
 	description?: string;
 	git: GitConfig;
+	document?: Document;
 }

--- a/packages/core/types/memory.ts
+++ b/packages/core/types/memory.ts
@@ -23,5 +23,5 @@ export interface Memory {
 	name: string;
 	description?: string;
 	git: GitConfig;
-	document?: Document;
+	documents?: Document;
 }


### PR DESCRIPTION
This PR adds the ability to dynamically set document metadata using memory config.

```ts
import {MemoryI} from '@baseai/core';

const memoryAiAgentMemory = (): MemoryI => ({
	name: 'ai-agent-memory',
	description: 'My list of docs as memory for an AI agent pipe',
	git: {
		enabled: true,
		include: ['**/*'],
		gitignore: true,
		deployedAt: '',
		embeddedAt: '',
	},
	document: {
		meta: doc => {
			return {
				name: doc.name,
				path: doc.path,
			};
		},
	},
});

export default memoryAiAgentMemory;

```