### PR TITLE
📦 NEW: tools support in pipe.run() endpoint

### DIFF
--- a/examples/nextjs/app/api/langbase/pipes/run-tool-stream/route.ts
+++ b/examples/nextjs/app/api/langbase/pipes/run-tool-stream/route.ts
@@ -9,9 +9,10 @@ export async function POST(req: NextRequest) {
 	const pipe = new Pipe(pipeWithToolsStream());
 
 	// 2. Run the pipe with user messages and other run options.
-	let {stream, threadId} = (await pipe.run(
-		runOptions,
-	)) as unknown as RunResponseStream;
+	let {stream, threadId} = (await pipe.run({
+		...runOptions,
+		stream: true,
+	})) as unknown as RunResponseStream;
 
 	// 3. Stream the response.
 	return new Response(stream, {

--- a/packages/baseai/src/dev/llms/call-anthropic.ts
+++ b/packages/baseai/src/dev/llms/call-anthropic.ts
@@ -6,21 +6,24 @@ import { handleLlmError } from './utils';
 import type { ModelParams } from 'types/providers';
 import type { Message, Pipe } from 'types/pipe';
 import { addToolsToParams } from '../utils/add-tools-to-params';
+import type { PipeTool } from 'types/tools';
 
 export async function callAnthropic({
 	pipe,
 	messages,
 	llmApiKey,
-	stream
+	stream,
+	paramsTools
 }: {
 	pipe: Pipe;
 	llmApiKey: string;
 	stream: boolean;
 	messages: Message[];
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		const modelParams = buildModelParams(pipe, stream, messages);
-		addToolsToParams(modelParams, pipe);
+		addToolsToParams(modelParams, pipe, paramsTools);
 
 		// Transform params according to provider's format
 		const transformedRequestParams = transformToProviderRequest({

--- a/packages/baseai/src/dev/llms/call-google.ts
+++ b/packages/baseai/src/dev/llms/call-google.ts
@@ -6,21 +6,24 @@ import { applyJsonModeIfEnabledForGoogle, handleLlmError } from './utils';
 import type { ModelParams } from 'types/providers';
 import type { Message, Pipe } from 'types/pipe';
 import { addToolsToParams } from '../utils/add-tools-to-params';
+import type { PipeTool } from 'types/tools';
 
 export async function callGoogle({
 	pipe,
 	messages,
 	llmApiKey,
-	stream
+	stream,
+	paramsTools
 }: {
 	pipe: Pipe;
 	stream: boolean;
 	llmApiKey: string;
 	messages: Message[];
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		const modelParams = buildModelParams(pipe, stream, messages);
-		addToolsToParams(modelParams, pipe);
+		addToolsToParams(modelParams, pipe, paramsTools);
 
 		// Transform params according to provider's format
 		const transformedRequestParams = transformToProviderRequest({

--- a/packages/baseai/src/dev/llms/call-llm.ts
+++ b/packages/baseai/src/dev/llms/call-llm.ts
@@ -27,19 +27,22 @@ import { callPerplexity } from './call-perplexity';
 import { callTogether } from './call-together';
 import { callXAI } from './call-xai';
 import { getProvider } from '../utils/get-provider';
+import type { PipeTool } from 'types/tools';
 
 export async function callLLM({
 	pipe,
 	stream,
 	messages,
 	llmApiKey,
-	variables
+	variables,
+	paramsTools
 }: {
 	pipe: Pipe;
 	stream: boolean;
 	llmApiKey: string;
 	messages: Message[];
 	variables?: VariablesI;
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		// Get the model provider from the pipe.
@@ -70,7 +73,8 @@ export async function callLLM({
 				pipe,
 				stream,
 				messages,
-				llmApiKey
+				llmApiKey,
+				paramsTools
 			});
 		}
 
@@ -78,9 +82,10 @@ export async function callLLM({
 			dlog('ANTHROPIC', '✅');
 			return await callAnthropic({
 				pipe,
+				stream,
 				messages,
 				llmApiKey,
-				stream
+				paramsTools
 			});
 		}
 
@@ -88,9 +93,10 @@ export async function callLLM({
 			dlog('TOGETHER_AI', '✅');
 			return await callTogether({
 				pipe,
+				stream,
 				messages,
 				llmApiKey,
-				stream
+				paramsTools,
 			});
 		}
 
@@ -110,7 +116,8 @@ export async function callLLM({
 				pipe,
 				messages,
 				llmApiKey,
-				stream
+				stream,
+				paramsTools
 			});
 		}
 
@@ -120,7 +127,8 @@ export async function callLLM({
 				pipe,
 				messages,
 				llmApiKey,
-				stream
+				stream,
+				paramsTools
 			});
 		}
 

--- a/packages/baseai/src/dev/llms/call-openai.ts
+++ b/packages/baseai/src/dev/llms/call-openai.ts
@@ -7,17 +7,20 @@ import { applyJsonModeIfEnabled, handleLlmError } from './utils';
 import type { Message, Pipe } from 'types/pipe';
 import type { ModelParams } from 'types/providers';
 import { addToolsToParams } from '../utils/add-tools-to-params';
+import type { PipeTool } from 'types/tools';
 
 export async function callOpenAI({
 	pipe,
 	stream,
 	llmApiKey,
-	messages
+	messages,
+	paramsTools
 }: {
 	pipe: Pipe;
 	stream: boolean;
 	llmApiKey: string;
 	messages: Message[];
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		validateInput(pipe, messages);
@@ -25,7 +28,7 @@ export async function callOpenAI({
 		await moderateContent(openai, messages, pipe.moderate);
 
 		const modelParams = buildModelParams(pipe, stream, messages);
-		addToolsToParams(modelParams, pipe);
+		addToolsToParams(modelParams, pipe, paramsTools);
 		applyJsonModeIfEnabled(modelParams, pipe);
 
 		dlog('modelParams', modelParams);

--- a/packages/baseai/src/dev/llms/call-together.ts
+++ b/packages/baseai/src/dev/llms/call-together.ts
@@ -5,17 +5,20 @@ import { applyJsonModeIfEnabled, handleLlmError } from './utils';
 import type { Message, Pipe } from 'types/pipe';
 import type { ModelParams } from 'types/providers';
 import { addToolsToParams } from '../utils/add-tools-to-params';
+import type { PipeTool } from 'types/tools';
 
 export async function callTogether({
 	pipe,
 	messages,
 	llmApiKey,
-	stream
+	stream,
+	paramsTools
 }: {
 	pipe: Pipe;
 	llmApiKey: string;
 	stream: boolean;
 	messages: Message[];
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		const modelParams = buildModelParams(pipe, stream, messages);
@@ -29,7 +32,7 @@ export async function callTogether({
 		// Together behaves weirdly with stop value. Omitting it.
 		delete modelParams['stop'];
 		applyJsonModeIfEnabled(modelParams, pipe);
-		addToolsToParams(modelParams, pipe);
+		addToolsToParams(modelParams, pipe, paramsTools);
 		dlog('modelParams', modelParams);
 
 		return await together.chat.completions.create(modelParams as any);

--- a/packages/baseai/src/dev/llms/call-xai.ts
+++ b/packages/baseai/src/dev/llms/call-xai.ts
@@ -5,17 +5,20 @@ import { handleLlmError } from './utils';
 import type { Message, Pipe } from 'types/pipe';
 import type { ModelParams } from 'types/providers';
 import { addToolsToParams } from '../utils/add-tools-to-params';
+import type { PipeTool } from 'types/tools';
 
 export async function callXAI({
 	pipe,
 	stream,
 	llmApiKey,
-	messages
+	messages,
+	paramsTools
 }: {
 	pipe: Pipe;
 	stream: boolean;
 	llmApiKey: string;
 	messages: Message[];
+	paramsTools: PipeTool[] | undefined;
 }) {
 	try {
 		const modelParams = buildModelParams(pipe, stream, messages);
@@ -27,7 +30,7 @@ export async function callXAI({
 		});
 
 		// Add tools (functions) to modelParams
-		addToolsToParams(modelParams, pipe);
+		addToolsToParams(modelParams, pipe, paramsTools);
 		dlog('modelParams', modelParams);
 
 		return await groq.chat.completions.create(modelParams as any);

--- a/packages/baseai/src/dev/routes/v1/pipes/run.ts
+++ b/packages/baseai/src/dev/routes/v1/pipes/run.ts
@@ -44,6 +44,7 @@ const RequestBodySchema = z.object({
 	stream: z.boolean(),
 	messages: z.array(schemaMessage),
 	llmApiKey: z.string(),
+	tools: z.array(pipeToolSchema).optional(),
 	variables: VariablesSchema.optional()
 });
 
@@ -138,7 +139,8 @@ const handleRun = async (c: any) => {
 			messages,
 			llmApiKey,
 			stream,
-			variables
+			variables,
+			paramsTools: validatedBody.tools
 		});
 
 		return processLlmResponse(c, validatedBody, rawLlmResponse);

--- a/packages/baseai/src/dev/utils/add-tools-to-params.ts
+++ b/packages/baseai/src/dev/utils/add-tools-to-params.ts
@@ -13,7 +13,7 @@ export function addToolsToParams(
 	const hasParamsTools = paramsTools && paramsTools.length > 0;
 
 	// 1. If no tools are provided, return the modelParams as is
-	if (!paramsTools && !pipeTools.length) return modelParams;
+	if (!hasParamsTools && !pipeTools.length) return modelParams;
 
 	const [providerString, modelName] = pipe.model.split(':');
 	const provider = getProvider(providerString);

--- a/packages/baseai/types/tools.ts
+++ b/packages/baseai/types/tools.ts
@@ -10,14 +10,6 @@ export interface Tool {
 	};
 }
 
-export interface PipeTool {
-	type: 'function';
-	function: {
-		name: string;
-		description?: string;
-		parameters?: Record<string, any>;
-	};
-}
 export const pipeToolSchema = z.object({
 	type: z.literal('function'),
 	function: z.object({
@@ -26,3 +18,5 @@ export const pipeToolSchema = z.object({
 		parameters: z.record(z.any()).optional()
 	})
 });
+
+export type PipeTool = z.infer<typeof pipeToolSchema>;

--- a/packages/core/src/helpers/stream.ts
+++ b/packages/core/src/helpers/stream.ts
@@ -1,7 +1,7 @@
 import {ChatCompletionStream} from 'openai/lib/ChatCompletionStream';
 import {ChunkStream} from 'src/pipes';
 import {Stream} from 'openai/streaming';
-import {ToolCall} from 'types/pipes';
+import {ToolCallResult} from 'types/pipes';
 
 export interface Runner extends ChatCompletionStream<null> {}
 
@@ -91,7 +91,7 @@ export function handleResponseStream({
  */
 export async function getToolsFromStream(
 	stream: ReadableStream<any>,
-): Promise<ToolCall[]> {
+): Promise<ToolCallResult[]> {
 	let run = getRunner(stream);
 	const {choices} = await run.finalChatCompletion();
 	return choices[0].message.tool_calls;

--- a/packages/core/types/pipes.ts
+++ b/packages/core/types/pipes.ts
@@ -19,7 +19,7 @@ export interface Function {
 	arguments: string;
 }
 
-export interface ToolCall {
+export interface ToolCallResult {
 	id: string;
 	type: 'function';
 	function: Function;
@@ -30,7 +30,7 @@ export interface Message {
 	content: string | null;
 	name?: string;
 	tool_call_id?: string;
-	tool_calls?: ToolCall[];
+	tool_calls?: ToolCallResult[];
 }
 
 interface ToolFunction {
@@ -43,6 +43,15 @@ interface ToolChoiceFunction {
 }
 
 type ToolChoice = 'auto' | 'required' | ToolChoiceFunction;
+
+export interface Tools {
+	type: 'function';
+	function: {
+		name: string;
+		description?: string;
+		parameters?: Record<string, any>;
+	};
+}
 
 export type Model =
 	| OpenAIModels


### PR DESCRIPTION
This PR includes change to support `tools` in `pipe.run()`. Users can now send tool definition to run endpoint. 

1. If no tools exists in pipe, `tools` in pipe will be passed to the LLM.
2. If user sends tools in request params and tools also exists in pipe, run options tools are priortized.